### PR TITLE
Add fsync after creating new manifest

### DIFF
--- a/leveldb/session_util.go
+++ b/leveldb/session_util.go
@@ -453,6 +453,12 @@ func (s *session) newManifest(rec *sessionRecord, v *version) (err error) {
 	if err != nil {
 		return
 	}
+	if !s.o.GetNoSync() {
+		err = writer.Sync()
+		if err != nil {
+			return
+		}
+	}
 	err = s.stor.SetMeta(fd)
 	return
 }


### PR DESCRIPTION
This simple PR adds an fsync call on the manifest file when a new
manifest file is generated at the start.

In absence of this, the code updates the "CURRENT" and deletes the
previous manifest file and a crash at this point could leave the latest
manifest with a single incomplete record. Under this situation,
a restart is expected to lead to [manifest corrupt error](https://github.com/syndtr/goleveldb/blob/5c35d600f0caac04c20d52438103f1a7aa612598/leveldb/session.go#L192)
This seems to explain the error observed in issue#335. We too have observed this error in our environment.