### PR TITLE
Upgrade go versions and disable "go vet" for "tip"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 language: go
 
 go:
-  - 1.9.x
-  - 1.10.x
-  - 1.11.x
+  - 1.14.x
+  - 1.15.x
   - tip
 
 script:
-  - go vet ./...
+  - |
+    (set -e
+    if [ "$TRAVIS_GO_VERSION" != "tip" ]; then 
+      echo "executing go vet for go verion $TRAVIS_GO_VERSION"
+      go vet ./...
+    else
+      echo "skipping go vet for go verion $TRAVIS_GO_VERSION"
+    fi
+    )
   - go test -timeout 1h ./...
   - go test -timeout 30m -race -run "TestDB_(Concurrent|GoleveldbIssue74)" ./leveldb


### PR DESCRIPTION
This commit
- Upgrades go versions. Build fails for prior versions as they
do not use go modules
- Disables go vet for the "tip" till vet issues are fixed

Signed-off-by: manish <manish.sethi@gmail.com>